### PR TITLE
Refactor and test longitudinal study

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -90,17 +90,21 @@ exclude = '''
 # See: https://github.com/PyCQA/flake8/issues/234
 
 [tool.mypy]
-# Development-friendly mypy configuration
-# For focused development, use: mypy --ignore-missing-imports file.py
+# Very strict mypy configuration for high-quality type checking
 python_version = "3.8"
-warn_return_any = false
+follow_imports = "skip"  # Avoid optype internal error in dependencies
+strict = true
+warn_return_any = true
 warn_unused_configs = true
-disallow_untyped_defs = false  # Set to true once codebase has more type annotations
-ignore_missing_imports = true  # Ignore third-party libraries without types
-follow_imports = "normal"      # Change to "skip" for faster, focused checking
+warn_redundant_casts = true
+warn_unused_ignores = true
+warn_unreachable = true
+disallow_any_generics = true
+disallow_subclassing_any = true
+# Display settings
 show_error_codes = true
 pretty = true
-
+error_summary = true
 # Exclude data and build directories
 exclude = [
     "pytheranostics/data/",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -114,6 +114,9 @@ exclude = [
     ".mypy_cache/",
 ]
 
+[tool.isort]
+profile = "black"
+
 [tool.pytest.ini_options]
 markers = [
     "smoke: marks tests as smoke tests (quick functionality checks)",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -126,3 +126,7 @@ filterwarnings = [
     "ignore:.*SwigPy.*:DeprecationWarning",
     "ignore:.*swigvar.*:DeprecationWarning",
 ]
+# Run smoke tests first and stop on first failure
+addopts = "--tb=short -x"
+# Test collection ordering: smoke tests first
+testpaths = ["tests"]

--- a/pytheranostics/ImagingDS/longitudinal_study.py
+++ b/pytheranostics/ImagingDS/longitudinal_study.py
@@ -48,8 +48,13 @@ class LongitudinalStudy:
             of valid mask names for regions of interest including organs, glands, and lesions.
         """
 
-        # TODO Consistency checks: verify that all time points are present in images, masks and meta.
+        if images.keys() != meta.keys():
+            raise ValueError(
+                "Not all time points have corresponding images and metadata."
+            )
+
         # TODO Consistency checks: verify that there are no missing masks across time points.
+        # NOTE: Such consistency would involve running add_mask_to_time_point() in __init__
 
         if modality not in ["NM", "PT", "CT", "DOSE"]:
             raise ValueError(f"Modality {modality} is not supported.")
@@ -146,18 +151,36 @@ class LongitudinalStudy:
     def array_of_activity_at(
         self, time_id: int, region: Optional[str] = None
     ) -> NDArray[Any]:
-        """Returns the array in units of activity in Bq, with the posibility of masking out for one specific region."""
+        """Returns the array in units of activity in Bq, with the posibility of masking
+        out for one specific region."""
         if self.modality not in ["NM", "PT"]:
-            raise AssertionError(
-                f"Activity can't be calculated from {self.modality} data."
-            )
+            raise ValueError(f"Activity can't be calculated from {self.modality} data.")
+
+        if time_id not in self.images:
+            raise ValueError(f"Time ID {time_id} not found in dataset.")
 
         array = self.array_at(time_id=time_id)
-        mask = (
-            self.masks[time_id][region]
-            if region is not None
-            else numpy.ones(shape=array.shape, dtype=numpy.int8)
-        )
+
+        if region is None:
+            mask = numpy.ones(shape=array.shape, dtype=numpy.bool_)
+        else:
+            if time_id not in self.masks:
+                raise ValueError(
+                    f"Time ID {time_id} does not include mask data. Did you run "
+                    "add_masks_to_time_point()?"
+                )
+            if region not in self.masks[time_id]:
+                available_regions = list(self.masks[time_id].keys())
+                raise ValueError(
+                    f"Region {region} not found in masks for time ID {time_id}. "
+                    f"Available regions: {available_regions}"
+                )
+            if self.masks[time_id][region].shape != array.shape:
+                raise ValueError(
+                    f"Mask shape {self.masks[time_id][region].shape} doesn't match "
+                    f"array shape {array.shape} for time ID {time_id}"
+                )
+            mask = self.masks[time_id][region]
 
         return array * mask * self.voxel_volume(time_id=time_id)
 
@@ -203,15 +226,18 @@ class LongitudinalStudy:
                     f"Warning: {mask_target} found at Time = {time_id}. It will be over-written!"
                 )
 
-            # Masks are in the right orientation and spacing, however there could be discrepancies in array
-            # shapes (reason, unknown). We resample to ensure shapes between image and masks are consistent TODO: Fix.
+            # Masks are in the right orientation and spacing, however there could be discrepancies
+            # in array shapes (reason, unknown). We resample to ensure shapes between image and
+            # masks are consistent.
+            # TODO: Fix.
             mask_ = resample_mask_to_target(
                 mask_img=masks[mask_source], target_img=self.images[time_id]
             )
 
-            self.masks[time_id][mask_target] = numpy.transpose(
+            mask_array = numpy.transpose(
                 SimpleITK.GetArrayFromImage(mask_), axes=(1, 2, 0)
             )
+            self.masks[time_id][mask_target] = mask_array.astype(numpy.bool_)
 
         return None
 

--- a/pytheranostics/ImagingDS/longitudinal_study.py
+++ b/pytheranostics/ImagingDS/longitudinal_study.py
@@ -1,4 +1,5 @@
 import os
+import re
 from pathlib import Path
 from typing import Any, Dict, List, Optional
 
@@ -20,8 +21,7 @@ class LongitudinalStudy:
     """Longitudinal Study Data Class to hold multiple medical imaging datasets, alongside with masks for organs
     /regions of interest and meta-data."""
 
-    # Mask mapping format:
-    _VALID_MASKS = [
+    _VALID_ORGAN_NAMES = [
         "Kidney_Left",
         "Kidney_Right",
         "Liver",
@@ -36,7 +36,7 @@ class LongitudinalStudy:
         "WholeBody",
         "RemainderOfBody",
         "TotalTumorBurden",
-    ] + [f"Lesion_{i}" for i in range(1, 100_000)]
+    ]
 
     def __init__(
         self,
@@ -139,6 +139,19 @@ class LongitudinalStudy:
             modality=internal_modality,
         )
 
+    @staticmethod
+    def _is_valid_mask_name(mask_name: str) -> bool:
+        """Check if a mask name is valid.
+
+        Valid names are either:
+        - Standard organ names from _VALID_ORGAN_NAMES
+        - Lesion names in format 'Lesion_N' where N is a positive integer
+        """
+        if mask_name in LongitudinalStudy._VALID_ORGAN_NAMES:
+            return True
+        lesion_pattern = r"^Lesion_([1-9]\d*)$"
+        return bool(re.match(lesion_pattern, mask_name))
+
     def array_at(self, time_id: int) -> NDArray[Any]:
         """Access Array Data"""
         return numpy.transpose(
@@ -214,9 +227,10 @@ class LongitudinalStudy:
                     f"{mask_source} is not part of the available masks: {masks.keys()}"
                 )
 
-            if mask_target not in self._VALID_MASKS:
+            if not self._is_valid_mask_name(mask_target):
                 raise ValueError(
-                    f"{mask_target} is not a valid mask name. Please use one of: {self._VALID_MASKS}"
+                    f"{mask_target} is not a valid mask name. Please use one of: "
+                    f"\n{self._VALID_ORGAN_NAMES}\nor 'Lesion_N' where N is a positive integer."
                 )
 
             if mask_target in self.masks[time_id]:

--- a/pytheranostics/ImagingDS/longitudinal_study.py
+++ b/pytheranostics/ImagingDS/longitudinal_study.py
@@ -20,6 +20,24 @@ class LongitudinalStudy:
     """Longitudinal Study Data Class to hold multiple medical imaging datasets, alongside with masks for organs
     /regions of interest and meta-data."""
 
+    # Mask mapping format:
+    _VALID_MASKS = [
+        "Kidney_Left",
+        "Kidney_Right",
+        "Liver",
+        "Spleen",
+        "Bladder",
+        "SubmandibularGland_Left",
+        "SubmandibularGland_Right",
+        "ParotidGland_Left",
+        "ParotidGland_Right",
+        "BoneMarrow",
+        "Skeleton",
+        "WholeBody",
+        "RemainderOfBody",
+        "TotalTumorBurden",
+    ] + [f"Lesion_{i}" for i in range(1, 100_000)]
+
     def __init__(
         self,
         images: Dict[int, SimpleITK.Image],
@@ -61,31 +79,11 @@ class LongitudinalStudy:
 
         self.modality = modality
         self.images = images
+        self.meta = meta
         self.masks: Dict[int, Dict[str, NDArray[numpy.bool_]]] = (
             {}
         )  # {time_id: {mask_name: array}}
 
-        self.meta = meta
-
-        # Mask mapping format:
-        self._valid_masks = [
-            "Kidney_Left",
-            "Kidney_Right",
-            "Liver",
-            "Spleen",
-            "Bladder",
-            "SubmandibularGland_Left",
-            "SubmandibularGland_Right",
-            "ParotidGland_Left",
-            "ParotidGland_Right",
-            "BoneMarrow",
-            "Skeleton",
-            "WholeBody",
-            "RemainderOfBody",
-            "TotalTumorBurden",
-        ]
-        lesion_masks = [f"Lesion_{i}" for i in range(1, 1000000)]
-        self._valid_masks.extend(lesion_masks)
         return None
 
     @classmethod
@@ -216,9 +214,9 @@ class LongitudinalStudy:
                     f"{mask_source} is not part of the available masks: {masks.keys()}"
                 )
 
-            if mask_target not in self._valid_masks:
+            if mask_target not in self._VALID_MASKS:
                 raise ValueError(
-                    f"{mask_target} is not a valid mask name. Please use one of: {self._valid_masks}"
+                    f"{mask_target} is not a valid mask name. Please use one of: {self._VALID_MASKS}"
                 )
 
             if mask_target in self.masks[time_id]:

--- a/pytheranostics/ImagingDS/longitudinal_study.py
+++ b/pytheranostics/ImagingDS/longitudinal_study.py
@@ -83,6 +83,59 @@ class LongitudinalStudy:
         self._valid_masks.extend(lesion_masks)
         return None
 
+    @classmethod
+    def from_dicom(
+        cls,
+        dicom_dirs: List[str],
+        modality: str = "CT",
+        calibration_factor: Optional[float] = None,
+    ) -> "LongitudinalStudy":
+        """Create a LongitudinalStudy object from a list of DICOM directories.
+
+        Currently assumes the order of the list corresponds to the order of the time points.
+
+        Args:
+            dicom_dirs (List[str]): List of paths to DICOM directories, each containing
+                images for one time point in the longitudinal study.
+            modality (str, optional): The imaging modality. Supported values are "CT"
+                and "Lu177_SPECT". Defaults to "CT".
+            calibration_factor (float, optional): Converts reconstructed SPECT image
+                (raw counts * num_proj) to units of Bq/mL. Defaults to None.
+
+        Returns:
+            LongitudinalStudy: A new LongitudinalStudy instance containing the loaded
+                DICOM data organized by time points.
+
+        Raises:
+            ValueError: If the specified modality is not supported.
+        """
+        # TODO: should fix this to make it robust and look at dicom header info for sorting time-points.
+        supported_modalities = {
+            "CT": "CT",
+            "Lu177_SPECT": "NM",
+        }
+        if modality not in supported_modalities.keys():
+            raise ValueError(
+                f"Modality '{modality}' not supported. Currently, the following modalities are supported: {list(supported_modalities.keys())}"
+            )
+        internal_modality = supported_modalities[modality]
+
+        images: Dict[int, SimpleITK.Image] = {}
+        metadata: Dict[int, ImagingMetadata] = {}
+
+        for time_id, dicom_dir in enumerate(dicom_dirs):
+            image, meta = load_from_dicom_dir(
+                dir=dicom_dir, modality=modality, calibration_factor=calibration_factor
+            )
+            images[time_id] = image
+            metadata[time_id] = meta
+
+        return cls(
+            images=images,
+            meta=metadata,
+            modality=internal_modality,
+        )
+
     def array_at(self, time_id: int) -> NDArray[Any]:
         """Access Array Data"""
         return numpy.transpose(
@@ -369,41 +422,3 @@ class LongitudinalStudy:
         )
 
         return None
-
-
-# TODO: Find the proper placement. Currently here to avoid circular imports. Consider making it part of the init class.
-def create_logitudinal_from_dicom(
-    dicom_dirs: List[str],
-    modality: str = "CT",
-    calibration_factor: Optional[float] = None,
-) -> LongitudinalStudy:
-    """Creates a LongitudinalStudy object from a list of dicom dirs. Currently it assumes the order of the list
-    corresponds to the order of the time points.
-
-    Args:
-        dicom_dirs (List[str]): _description_
-        modality (str, optional): _description_. Defaults to "CT".
-        calibration_factor (float, optional): Converts reconstructed SPECT image (raw counts * num_proj) to units of Bq / mL. Defatuls to 1.
-    Returns:
-        LongitudinalStudy: _description_
-    """
-    # TODO: should fix this to make it robust and look at dicom header info for sorting time-points.
-    mod_supported = ["CT", "Lu177_SPECT"]
-    if modality not in mod_supported:
-        raise NotImplementedError(
-            f"{modality} not supported. Currently, the following  modalities are supported: {mod_supported}"
-        )
-
-    images: Dict[int, SimpleITK.Image] = {}
-    metadata: Dict[int, ImagingMetadata] = {}
-
-    for time_id, dir in enumerate(dicom_dirs):
-        image, meta = load_from_dicom_dir(
-            dir=dir, modality=modality, calibration_factor=calibration_factor
-        )
-        images[time_id] = image
-        metadata[time_id] = meta
-
-    return LongitudinalStudy(
-        images=images, meta=metadata, modality=modality if modality == "CT" else "NM"
-    )

--- a/pytheranostics/ImagingDS/longitudinal_study.py
+++ b/pytheranostics/ImagingDS/longitudinal_study.py
@@ -4,7 +4,6 @@ from typing import Dict, List, Optional
 
 import numpy
 import SimpleITK
-from SimpleITK import Image
 
 from pytheranostics.ImagingDS.metadata import ImagingMetadata
 from pytheranostics.ImagingTools.Tools import (
@@ -377,7 +376,7 @@ def create_logitudinal_from_dicom(
             f"{modality} not supported. Currently, the following  modalities are supported: {mod_supported}"
         )
 
-    images: Dict[int, Image] = {}
+    images: Dict[int, SimpleITK.Image] = {}
     metadata: Dict[int, ImagingMetadata] = {}
 
     for time_id, dir in enumerate(dicom_dirs):

--- a/pytheranostics/ImagingDS/longitudinal_study.py
+++ b/pytheranostics/ImagingDS/longitudinal_study.py
@@ -1,9 +1,10 @@
 import os
 from pathlib import Path
-from typing import Dict, List, Optional
+from typing import Any, Dict, List, Optional
 
 import numpy
 import SimpleITK
+from numpy.typing import NDArray
 
 from pytheranostics.ImagingDS.metadata import ImagingMetadata
 from pytheranostics.ImagingTools.Tools import (
@@ -25,9 +26,26 @@ class LongitudinalStudy:
         meta: Dict[int, ImagingMetadata],
         modality: str = "NM",
     ) -> None:
-        """
-        images: Dictionary of (time-point ID, numpy array) representing CT or quantitative nuclear medicine images.
-        meta: Dictionary of (time-point ID, ImagingMetadata dataclass) representing meta-data for each time point.
+        """Initialize a LongitudinalStudy instance.
+
+        Args:
+            images (Dict[int, SimpleITK.Image]): Dictionary of (time-point ID, SimpleITK.Image)
+                representing CT or quantitative nuclear medicine images for each time point
+                in the longitudinal study.
+            meta (Dict[int, ImagingMetadata]): Dictionary of (time-point ID, ImagingMetadata)
+                representing metadata for each time point, containing acquisition details
+                and radionuclide information.
+            modality (str, optional): The imaging modality type. Supported values are "NM"
+                (Nuclear Medicine), "PT" (PET), "CT", or "DOSE". Defaults to "NM".
+
+        Raises:
+            ValueError: If the specified modality is not one of the supported values:
+                "NM", "PT", "CT", or "DOSE".
+
+        Note:
+            The constructor initializes an empty masks dictionary that can be populated later
+            using the `add_masks_to_time_point` method. It also defines a comprehensive list
+            of valid mask names for regions of interest including organs, glands, and lesions.
         """
 
         # TODO Consistency checks: verify that all time points are present in images, masks and meta.
@@ -38,7 +56,7 @@ class LongitudinalStudy:
 
         self.modality = modality
         self.images = images
-        self.masks: Dict[int, Dict[str, numpy.ndarray]] = (
+        self.masks: Dict[int, Dict[str, NDArray[numpy.bool_]]] = (
             {}
         )  # {time_id: {mask_name: array}}
 
@@ -65,7 +83,7 @@ class LongitudinalStudy:
         self._valid_masks.extend(lesion_masks)
         return None
 
-    def array_at(self, time_id: int) -> numpy.ndarray:
+    def array_at(self, time_id: int) -> NDArray[Any]:
         """Access Array Data"""
         return numpy.transpose(
             numpy.squeeze(SimpleITK.GetArrayFromImage(self.images[time_id])),
@@ -74,7 +92,7 @@ class LongitudinalStudy:
 
     def array_of_activity_at(
         self, time_id: int, region: Optional[str] = None
-    ) -> numpy.ndarray:
+    ) -> NDArray[Any]:
         """Returns the array in units of activity in Bq, with the posibility of masking out for one specific region."""
         if self.modality not in ["NM", "PT"]:
             raise AssertionError(
@@ -165,14 +183,14 @@ class LongitudinalStudy:
 
     def density_of(self, region: str, time_id: int) -> float:
         """Returns the mean density of region of interest, in HU"""
-        return numpy.mean(
-            self.array_at(time_id=time_id)[self.masks[time_id][region] > 0]
+        return float(
+            numpy.mean(self.array_at(time_id=time_id)[self.masks[time_id][region] > 0])
         )
 
     def voxel_volume(self, time_id: int) -> float:
         """Returns the volume of a voxel in mL"""
         spacing = self.images[time_id].GetSpacing()
-        return spacing[0] / 10 * spacing[1] / 10 * spacing[2] / 10
+        return float(spacing[0] / 10 * spacing[1] / 10 * spacing[2] / 10)
 
     def average_of(self, region: str, time_id: int) -> float:
         """_summary_
@@ -184,8 +202,8 @@ class LongitudinalStudy:
         Returns:
             float: _description_
         """
-        return numpy.average(
-            self.array_at(time_id=time_id)[self.masks[time_id][region]]
+        return float(
+            numpy.average(self.array_at(time_id=time_id)[self.masks[time_id][region]])
         )
 
     def add_bone_marrow_mask_from_phantom(

--- a/pytheranostics/dosimetry/BaseDosimetry.py
+++ b/pytheranostics/dosimetry/BaseDosimetry.py
@@ -10,7 +10,7 @@ import pandas
 
 from pytheranostics.dosimetry.BoneMarrow import bm_scaling_factor
 from pytheranostics.fits.fits import exponential_fit_lmfit
-from pytheranostics.ImagingDS.LongStudy import LongitudinalStudy
+from pytheranostics.ImagingDS.longitudinal_study import LongitudinalStudy
 from pytheranostics.ImagingTools.Tools import extract_masks
 from pytheranostics.MiscTools.Tools import calculate_time_difference
 from pytheranostics.plots.plots import plot_tac_residuals

--- a/pytheranostics/dosimetry/OrganSDosimetry.py
+++ b/pytheranostics/dosimetry/OrganSDosimetry.py
@@ -1,6 +1,6 @@
 from pytheranostics.dosimetry.BaseDosimetry import BaseDosimetry
 from typing import Any, Dict, Optional
-from pytheranostics.ImagingDS.LongStudy import LongitudinalStudy
+from pytheranostics.ImagingDS.longitudinal_study import LongitudinalStudy
 from scipy.interpolate import PchipInterpolator
 from typing import Tuple
 import datetime

--- a/pytheranostics/dosimetry/VoxelSDosimetry.py
+++ b/pytheranostics/dosimetry/VoxelSDosimetry.py
@@ -10,7 +10,7 @@ from pandas import DataFrame
 from pytheranostics.dosimetry.BaseDosimetry import BaseDosimetry
 from pytheranostics.dosimetry.dvk import DoseVoxelKernel
 from pytheranostics.fits.fits import get_exponential
-from pytheranostics.ImagingDS.LongStudy import LongitudinalStudy
+from pytheranostics.ImagingDS.longitudinal_study import LongitudinalStudy
 from pytheranostics.ImagingTools.Tools import itk_image_from_array, resample_to_target
 
 
@@ -100,7 +100,7 @@ class VoxelSDosimetry(BaseDosimetry):
                 region_mask.astype(numpy.float64) * region_tia * act_map_at_ref / f_to
             )  # MBq_h
 
-        # Create ITK Image Object and embed it into a LongStudy.  #TODO: modularize, repeated code downwards.
+        # Create ITK Image Object and embed it into a LongitudinalStudy.  #TODO: modularize, repeated code downwards.
         tia_image = itk_image_from_array(
             array=numpy.transpose(tia_map, axes=(2, 0, 1)),
             ref_image=self.nm_data.images[ref_time_id],
@@ -140,7 +140,7 @@ class VoxelSDosimetry(BaseDosimetry):
             ),
         )
 
-        # Create ITK Image Object and embed it into a LongStudy
+        # Create ITK Image Object and embed it into a LongitudinalStudy
         # Clear dose outside patient body:
         dose_map_array *= self.nm_data.masks[ref_time_id]["WholeBody"]
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -6,6 +6,23 @@ import numpy as np
 import pytest
 
 
+def pytest_collection_modifyitems(config, items):
+    """Modify test collection to run smoke tests first."""
+
+    # Separate smoke tests from other tests
+    smoke_tests = []
+    other_tests = []
+
+    for item in items:
+        if "smoke" in item.keywords:
+            smoke_tests.append(item)
+        else:
+            other_tests.append(item)
+
+    # Reorder: smoke tests first, then others
+    items[:] = smoke_tests + other_tests
+
+
 @pytest.fixture
 def sample_image():
     """Create a sample image for testing."""

--- a/tests/test_longitudinal_study.py
+++ b/tests/test_longitudinal_study.py
@@ -1,0 +1,500 @@
+"""Test suite for LongitudinalStudy class.
+
+This test suite uses minimal data objects and property-based testing
+to validate the LongitudinalStudy class functionality without requiring
+large medical imaging datasets.
+"""
+
+from unittest.mock import MagicMock, patch
+
+import numpy as np
+import pytest
+import SimpleITK
+
+from pytheranostics.ImagingDS.longitudinal_study import LongitudinalStudy
+from pytheranostics.ImagingDS.metadata import ImagingMetadata
+
+
+class TestLongitudinalStudyFixtures:
+    """Test fixtures and helper methods for LongitudinalStudy testing."""
+
+    @staticmethod
+    def create_mock_sitk_image(
+        shape=(10, 10, 10), spacing=(1.0, 1.0, 1.0), origin=(0.0, 0.0, 0.0)
+    ):
+        """Create a minimal mock SimpleITK image for testing.
+
+        Args:
+            shape: Image dimensions (x, y, z)
+            spacing: Voxel spacing (x, y, z)
+            origin: Image origin (x, y, z)
+
+        Returns:
+            Mock SimpleITK.Image with minimal required functionality
+        """
+        mock_image = MagicMock(spec=SimpleITK.Image)
+        mock_image.GetSpacing.return_value = spacing
+        mock_image.GetOrigin.return_value = origin
+        mock_image.GetSize.return_value = shape
+        mock_image.GetPixelIDValue.return_value = 1  # sitkUInt8 = 1
+
+        return mock_image
+
+    @staticmethod
+    def create_test_metadata(
+        patient_id="TEST_001",
+        acquisition_date="20250101",
+        acquisition_time="120000",
+        hours_after_injection=24.0,
+        radionuclide="Lu-177",
+        injected_activity_mbq=7400.0,
+    ):
+        """Create test metadata with sensible defaults."""
+        return ImagingMetadata(
+            PatientID=patient_id,
+            AcquisitionDate=acquisition_date,
+            AcquisitionTime=acquisition_time,
+            HoursAfterInjection=hours_after_injection,
+            Radionuclide=radionuclide,
+            Injected_Activity_MBq=injected_activity_mbq,
+        )
+
+    @staticmethod
+    def create_minimal_study(num_timepoints=2, modality="NM", image_shape=(10, 10, 10)):
+        """Create a minimal LongitudinalStudy for testing.
+
+        Args:
+            num_timepoints: Number of time points to create
+            modality: Imaging modality
+            image_shape: Shape of mock images
+
+        Returns:
+            LongitudinalStudy instance with mock data
+        """
+        images = {}
+        meta = {}
+
+        for time_id in range(num_timepoints):
+            # Create mock image
+            mock_image = MagicMock(spec=SimpleITK.Image)
+            mock_image.GetSpacing.return_value = (1.0, 1.0, 1.0)
+            mock_image.GetOrigin.return_value = (0.0, 0.0, 0.0)
+            mock_image.GetSize.return_value = image_shape
+            mock_image.GetPixelIDValue.return_value = 1  # sitkUInt8 = 1
+            images[time_id] = mock_image
+
+            # Create metadata
+            meta[time_id] = TestLongitudinalStudyFixtures.create_test_metadata(
+                patient_id=f"TEST_{time_id:03d}",
+                hours_after_injection=24.0 + time_id * 24.0,
+            )
+
+        return LongitudinalStudy(images=images, meta=meta, modality=modality)
+
+
+class TestLongitudinalStudyInit:
+    """Test LongitudinalStudy initialization and validation."""
+
+    def test_init_success_minimal(self):
+        """Test successful initialization with minimal valid data."""
+        study = TestLongitudinalStudyFixtures.create_minimal_study()
+
+        assert study.modality == "NM"
+        assert len(study.images) == 2
+        assert len(study.meta) == 2
+        assert len(study.masks) == 0
+        assert isinstance(study._valid_masks, list)
+        assert "Liver" in study._valid_masks
+        assert "Lesion_1" in study._valid_masks
+
+    def test_init_mismatched_keys_raises_error(self):
+        """Test that mismatched image and metadata keys raise ValueError."""
+        images = {0: MagicMock(spec=SimpleITK.Image)}
+        meta = {1: TestLongitudinalStudyFixtures.create_test_metadata()}
+
+        with pytest.raises(
+            ValueError,
+            match="Not all time points have corresponding images and metadata",
+        ):
+            LongitudinalStudy(images=images, meta=meta)
+
+    @pytest.mark.parametrize("modality", ["NM", "PT", "CT", "DOSE"])
+    def test_init_valid_modalities(self, modality):
+        """Test initialization with all valid modalities."""
+        study = TestLongitudinalStudyFixtures.create_minimal_study(modality=modality)
+        assert study.modality == modality
+
+    @pytest.mark.parametrize("invalid_modality", ["MRI", "US", "XR", "invalid"])
+    def test_init_invalid_modality_raises_error(self, invalid_modality):
+        """Test that invalid modalities raise ValueError."""
+        images = {0: MagicMock(spec=SimpleITK.Image)}
+        meta = {0: TestLongitudinalStudyFixtures.create_test_metadata()}
+
+        with pytest.raises(
+            ValueError, match=f"Modality {invalid_modality} is not supported"
+        ):
+            LongitudinalStudy(images=images, meta=meta, modality=invalid_modality)
+
+    def test_init_creates_lesion_masks(self):
+        """Test that initialization creates expected number of lesion masks."""
+        study = TestLongitudinalStudyFixtures.create_minimal_study()
+
+        lesion_masks = [
+            mask for mask in study._valid_masks if mask.startswith("Lesion_")
+        ]
+        assert len(lesion_masks) == 999999  # Lesion_1 through Lesion_999999
+
+
+class TestLongitudinalStudyArrayAccess:
+    """Test array access methods with mock data."""
+
+    @patch("SimpleITK.GetArrayFromImage")
+    def test_array_at_success(self, mock_get_array):
+        """Test successful array access."""
+        # Setup mock return value
+        test_array = np.random.rand(10, 10, 10)
+        mock_get_array.return_value = test_array
+
+        study = TestLongitudinalStudyFixtures.create_minimal_study()
+
+        result = study.array_at(time_id=0)
+
+        # Verify the array is transposed correctly
+        expected_shape = (test_array.shape[1], test_array.shape[2], test_array.shape[0])
+        assert result.shape == expected_shape
+        mock_get_array.assert_called_once()
+
+    def test_array_at_invalid_time_id(self):
+        """Test array access with invalid time_id."""
+        study = TestLongitudinalStudyFixtures.create_minimal_study()
+
+        with pytest.raises(KeyError):
+            study.array_at(time_id=999)
+
+
+class TestLongitudinalStudyActivityCalculations:
+    """Test activity-related calculations."""
+
+    @patch("SimpleITK.GetArrayFromImage")
+    def test_array_of_activity_at_invalid_modality(self, mock_get_array):
+        """Test that activity calculation fails for non-nuclear modalities."""
+        study = TestLongitudinalStudyFixtures.create_minimal_study(modality="CT")
+
+        with pytest.raises(
+            ValueError, match="Activity can't be calculated from CT data"
+        ):
+            study.array_of_activity_at(time_id=0)
+
+    @patch("SimpleITK.GetArrayFromImage")
+    def test_array_of_activity_at_invalid_time_id(self, mock_get_array):
+        """Test activity calculation with invalid time_id."""
+        study = TestLongitudinalStudyFixtures.create_minimal_study(modality="NM")
+
+        with pytest.raises(ValueError, match="Time ID 999 not found in dataset"):
+            study.array_of_activity_at(time_id=999)
+
+    @patch("SimpleITK.GetArrayFromImage")
+    def test_array_of_activity_at_no_region_creates_ones_mask(self, mock_get_array):
+        """Test that activity calculation without region creates ones mask."""
+        test_array = np.random.rand(5, 5, 5)
+        mock_get_array.return_value = test_array
+
+        study = TestLongitudinalStudyFixtures.create_minimal_study(modality="NM")
+
+        # Mock voxel_volume to return a simple value
+        study.voxel_volume = MagicMock(return_value=1.0)
+
+        result = study.array_of_activity_at(time_id=0, region=None)
+
+        # Should equal array * 1.0 (ones mask) * 1.0 (voxel volume)
+        # Note: array will be transposed, so we need to account for that
+        expected_shape = (test_array.shape[1], test_array.shape[2], test_array.shape[0])
+        assert result.shape == expected_shape
+
+    @patch("SimpleITK.GetArrayFromImage")
+    def test_array_of_activity_at_region_no_masks_raises_error(self, mock_get_array):
+        """Test that requesting region without masks raises appropriate error."""
+        study = TestLongitudinalStudyFixtures.create_minimal_study(modality="NM")
+
+        # Set up mock to return a realistic array
+        mock_get_array.return_value = np.random.rand(10, 10, 10)
+
+        with pytest.raises(ValueError, match="Time ID 0 does not include mask data"):
+            study.array_of_activity_at(time_id=0, region="Liver")
+
+    @patch("SimpleITK.GetArrayFromImage")
+    def test_array_of_activity_at_invalid_region_raises_error(self, mock_get_array):
+        """Test that requesting invalid region raises appropriate error."""
+        study = TestLongitudinalStudyFixtures.create_minimal_study(modality="NM")
+
+        # Set up mock to return a realistic array
+        mock_get_array.return_value = np.random.rand(10, 10, 10)
+
+        # Add empty masks dictionary for time_id 0
+        study.masks[0] = {"Liver": np.ones((10, 10, 10), dtype=np.bool_)}
+
+        with pytest.raises(ValueError, match="Region InvalidRegion not found"):
+            study.array_of_activity_at(time_id=0, region="InvalidRegion")
+
+
+class TestLongitudinalStudyMaskManagement:
+    """Test mask addition and validation."""
+
+    def test_add_masks_to_time_point_basic_success(self):
+        """Test basic mask addition functionality."""
+        study = TestLongitudinalStudyFixtures.create_minimal_study()
+
+        # Create mock mask image
+        mock_mask_image = MagicMock(spec=SimpleITK.Image)
+        masks = {"liver_mask": mock_mask_image}
+        mask_mapping = {"liver_mask": "Liver"}
+
+        # Mock the required functions
+        with patch(
+            "pytheranostics.ImagingDS.longitudinal_study.resample_mask_to_target"
+        ) as mock_resample, patch("SimpleITK.GetArrayFromImage") as mock_get_array:
+
+            mock_resample.return_value = mock_mask_image
+            mock_get_array.return_value = np.ones((10, 10, 10), dtype=np.uint8)
+
+            study.add_masks_to_time_point(
+                time_id=0, masks=masks, mask_mapping=mask_mapping
+            )
+
+            assert 0 in study.masks
+            assert "Liver" in study.masks[0]
+            assert study.masks[0]["Liver"].dtype == np.bool_
+
+    def test_add_masks_invalid_source_mask_raises_error(self):
+        """Test that invalid source mask name raises error."""
+        study = TestLongitudinalStudyFixtures.create_minimal_study()
+
+        masks = {"existing_mask": MagicMock(spec=SimpleITK.Image)}
+        mask_mapping = {"nonexistent_mask": "Liver"}
+
+        with pytest.raises(
+            ValueError, match="nonexistent_mask is not part of the available masks"
+        ):
+            study.add_masks_to_time_point(
+                time_id=0, masks=masks, mask_mapping=mask_mapping
+            )
+
+    def test_add_masks_invalid_target_mask_raises_error(self):
+        """Test that invalid target mask name raises error."""
+        study = TestLongitudinalStudyFixtures.create_minimal_study()
+
+        masks = {"liver_mask": MagicMock(spec=SimpleITK.Image)}
+        mask_mapping = {"liver_mask": "InvalidOrgan"}
+
+        with pytest.raises(ValueError, match="InvalidOrgan is not a valid mask name"):
+            study.add_masks_to_time_point(
+                time_id=0, masks=masks, mask_mapping=mask_mapping
+            )
+
+
+class TestLongitudinalStudyVolumeCalculations:
+    """Test volume and density calculations."""
+
+    def test_voxel_volume_calculation(self):
+        """Test voxel volume calculation."""
+        study = TestLongitudinalStudyFixtures.create_minimal_study()
+
+        # Mock image with known spacing
+        study.images[0].GetSpacing.return_value = (2.0, 3.0, 4.0)  # mm
+
+        expected_volume = (
+            (2.0 / 10) * (3.0 / 10) * (4.0 / 10)
+        )  # Convert mm to cm then to mL
+        actual_volume = study.voxel_volume(time_id=0)
+
+        assert abs(actual_volume - expected_volume) < 1e-10
+
+    def test_volume_of_region(self):
+        """Test volume calculation for a region."""
+        study = TestLongitudinalStudyFixtures.create_minimal_study()
+
+        # Create a mask with known number of voxels
+        mask = np.zeros((10, 10, 10), dtype=np.bool_)
+        mask[0:5, 0:5, 0:5] = True  # 125 voxels
+        study.masks[0] = {"Liver": mask}
+
+        # Mock voxel volume
+        study.voxel_volume = MagicMock(return_value=0.001)  # 1 mm³ = 0.001 mL
+
+        volume = study.volume_of(region="Liver", time_id=0)
+
+        assert volume == 125 * 0.001  # 125 voxels * 0.001 mL/voxel
+
+
+class TestLongitudinalStudyPropertyBased:
+    """Property-based tests for LongitudinalStudy."""
+
+    @pytest.mark.parametrize("num_timepoints", [1, 2, 5, 10])
+    def test_consistent_timepoint_keys(self, num_timepoints):
+        """Property: images and meta should always have same keys."""
+        study = TestLongitudinalStudyFixtures.create_minimal_study(
+            num_timepoints=num_timepoints
+        )
+
+        assert study.images.keys() == study.meta.keys()
+        assert len(study.images) == num_timepoints
+        assert len(study.meta) == num_timepoints
+
+    @pytest.mark.parametrize("shape", [(5, 5, 5), (10, 20, 30)])
+    def test_array_transpose_consistency(self, shape):
+        """Property: array_at should consistently transpose dimensions."""
+        study = TestLongitudinalStudyFixtures.create_minimal_study(image_shape=shape)
+
+        with patch("SimpleITK.GetArrayFromImage") as mock_get_array:
+            # SimpleITK returns arrays in (z, y, x) order
+            test_array = np.random.rand(*shape[::-1])  # shape[::-1] gives (z, y, x)
+            mock_get_array.return_value = test_array
+
+            result = study.array_at(time_id=0)
+
+            # Result should be transposed (1, 2, 0) from (z, y, x) to (y, x, z)
+            # Original shape: (shape[2], shape[1], shape[0]) = (z, y, x)
+            # After transpose (1, 2, 0): (shape[1], shape[0], shape[2]) = (y, x, z)
+            expected_shape = (shape[1], shape[0], shape[2])
+            assert result.shape == expected_shape
+
+    def test_mask_validation_completeness(self):
+        """Property: all standard organ masks should be in valid_masks."""
+        study = TestLongitudinalStudyFixtures.create_minimal_study()
+
+        required_organs = [
+            "Kidney_Left",
+            "Kidney_Right",
+            "Liver",
+            "Spleen",
+            "Bladder",
+            "BoneMarrow",
+            "Skeleton",
+            "WholeBody",
+        ]
+
+        for organ in required_organs:
+            assert organ in study._valid_masks
+
+
+class TestLongitudinalStudyIntegration:
+    """Integration tests that test multiple components working together."""
+
+    @patch("SimpleITK.GetArrayFromImage")
+    def test_end_to_end_activity_calculation_with_mask(self, mock_get_array):
+        """Integration test: Create study, add mask, calculate activity."""
+        # Setup
+        study = TestLongitudinalStudyFixtures.create_minimal_study(modality="NM")
+
+        # Mock array data - uniform activity of 100 Bq/ml
+        activity_data = np.full((10, 10, 10), 100.0)
+        mock_get_array.return_value = activity_data
+
+        # Add a liver mask covering half the volume
+        liver_mask = np.zeros((10, 10, 10), dtype=np.bool_)
+        liver_mask[0:5, :, :] = True  # Half the volume
+        study.masks[0] = {"Liver": liver_mask}
+
+        # Mock voxel volume
+        study.voxel_volume = MagicMock(return_value=0.001)  # 1 mm³
+
+        # Test
+        result = study.array_of_activity_at(time_id=0, region="Liver")
+
+        # Verify
+        # Should have activity only in masked region
+        assert np.sum(result > 0) == 500  # 5*10*10 voxels
+        assert np.all(result[5:, :, :] == 0)  # No activity outside mask
+        assert np.all(result[0:5, :, :] > 0)  # Activity inside mask
+
+    def test_multiple_timepoints_consistency(self):
+        """Integration test: Verify behavior is consistent across timepoints."""
+        study = TestLongitudinalStudyFixtures.create_minimal_study(num_timepoints=3)
+
+        # All timepoints should have same valid modality
+        assert all(study.modality == "NM" for _ in range(3))
+
+        # Should be able to access voxel volume for all timepoints
+        for time_id in [0, 1, 2]:
+            vol = study.voxel_volume(time_id)
+            assert isinstance(vol, float)
+            assert vol > 0
+
+
+class TestLongitudinalStudyEdgeCases:
+    """Test edge cases and boundary conditions."""
+
+    def test_empty_study_behavior(self):
+        """Test behavior when creating study with no timepoints."""
+        # Empty study should be created successfully but have empty dictionaries
+        study = LongitudinalStudy(images={}, meta={}, modality="NM")
+
+        assert len(study.images) == 0
+        assert len(study.meta) == 0
+        assert len(study.masks) == 0
+        assert study.modality == "NM"
+
+    @patch("SimpleITK.GetArrayFromImage")
+    def test_activity_calculation_with_zero_volume_mask(self, mock_get_array):
+        """Test behavior when mask has no True values."""
+        study = TestLongitudinalStudyFixtures.create_minimal_study(modality="NM")
+
+        mock_get_array.return_value = np.full((10, 10, 10), 100.0)
+        study.voxel_volume = MagicMock(return_value=0.001)
+
+        # Create empty mask (all False)
+        empty_mask = np.zeros((10, 10, 10), dtype=np.bool_)
+        study.masks[0] = {"EmptyRegion": empty_mask}
+
+        result = study.array_of_activity_at(time_id=0, region="EmptyRegion")
+
+        # Should return array of all zeros
+        assert np.all(result == 0)
+        assert result.shape == (10, 10, 10)
+
+    def test_lesion_numbering_edge_cases(self):
+        """Test that lesion numbering works for edge cases."""
+        study = TestLongitudinalStudyFixtures.create_minimal_study()
+
+        # Test boundary lesion numbers
+        assert "Lesion_1" in study._valid_masks
+        assert "Lesion_999999" in study._valid_masks
+
+        # Test that we have exactly the expected number
+        lesion_count = sum(
+            1 for mask in study._valid_masks if mask.startswith("Lesion_")
+        )
+        assert lesion_count == 999999
+
+
+class TestLongitudinalStudyPerformance:
+    """Test performance characteristics and scaling behavior."""
+
+    def test_large_timepoint_initialization(self):
+        """Test that initialization scales reasonably with number of timepoints."""
+        import time
+
+        start_time = time.time()
+        study = TestLongitudinalStudyFixtures.create_minimal_study(num_timepoints=100)
+        end_time = time.time()
+
+        # Should complete in reasonable time (less than 1 second)
+        assert (end_time - start_time) < 1.0
+        assert len(study.images) == 100
+        assert len(study.meta) == 100
+
+    @pytest.mark.parametrize("image_size", [(5, 5, 5), (50, 50, 50)])
+    def test_memory_efficiency_with_mocks(self, image_size):
+        """Test that our mocking doesn't consume excessive memory."""
+        study = TestLongitudinalStudyFixtures.create_minimal_study(
+            num_timepoints=10, image_shape=image_size
+        )
+
+        # Should be able to create study regardless of declared image size
+        # since we're using mocks
+        assert len(study.images) == 10
+        assert all(img.GetSize() == image_size for img in study.images.values())
+
+
+if __name__ == "__main__":
+    pytest.main([__file__])

--- a/tests/test_longitudinal_study.py
+++ b/tests/test_longitudinal_study.py
@@ -103,9 +103,9 @@ class TestLongitudinalStudyInit:
         assert len(study.images) == 2
         assert len(study.meta) == 2
         assert len(study.masks) == 0
-        assert isinstance(study._VALID_MASKS, list)
-        assert "Liver" in study._VALID_MASKS
-        assert "Lesion_1" in study._VALID_MASKS
+        assert isinstance(study._VALID_ORGAN_NAMES, list)
+        assert "Liver" in study._VALID_ORGAN_NAMES
+        assert LongitudinalStudy._is_valid_mask_name("Lesion_1")
 
     def test_init_mismatched_keys_raises_error(self):
         """Test that mismatched image and metadata keys raise ValueError."""
@@ -349,23 +349,51 @@ class TestLongitudinalStudyPropertyBased:
             expected_shape = (shape[1], shape[0], shape[2])
             assert result.shape == expected_shape
 
-    def test_mask_validation_completeness(self):
-        """Property: all standard organ masks should be in valid_masks."""
-        study = TestLongitudinalStudyFixtures.create_minimal_study()
+    @pytest.mark.parametrize(
+        "mask_name,expected",
+        [
+            # Valid organ names
+            ("Liver", True),
+            ("Spleen", True),
+            ("Kidney_Left", True),
+            ("Kidney_Right", True),
+            ("Bladder", True),
+            ("BoneMarrow", True),
+            ("WholeBody", True),
+            # Valid lesion formats
+            ("Lesion_1", True),
+            ("Lesion_42", True),
+            ("Lesion_99999", True),
+            # Invalid formats
+            ("lesion_1", False),  # lowercase
+            ("LESION_1", False),  # uppercase
+            ("leSIon_1", False),  # mixed case
+            ("Lesion_0", False),  # zero not allowed
+            ("Lesion_01", False),  # leading zero
+            ("Lesion_", False),  # missing number
+            ("Lesion_a", False),  # non-numeric
+            ("Lesion_1a", False),  # mixed alphanumeric
+            ("Lesion 1", False),  # space instead of underscore
+            ("Lesion-1", False),  # hyphen instead of underscore
+            # Edge cases
+            ("", False),  # empty string
+            ("Kidneys", False),  # not in valid list (plural vs Kidney_Left/Right)
+            ("Lungs", False),  # not in valid list
+            ("Tumor", False),  # not in valid list (use TotalTumorBurden or Lesion_N)
+            ("Background", False),  # not in valid list
+            ("Unknown", False),  # not in valid list
+            ("Random", False),  # not in valid list
+            ("Lesion_-1", False),  # negative number
+        ],
+    )
+    def test_mask_validation(self, mask_name, expected):
+        """Test comprehensive mask name validation patterns."""
+        from pytheranostics.ImagingDS.longitudinal_study import LongitudinalStudy
 
-        required_organs = [
-            "Kidney_Left",
-            "Kidney_Right",
-            "Liver",
-            "Spleen",
-            "Bladder",
-            "BoneMarrow",
-            "Skeleton",
-            "WholeBody",
-        ]
-
-        for organ in required_organs:
-            assert organ in study._VALID_MASKS
+        result = LongitudinalStudy._is_valid_mask_name(mask_name)
+        assert (
+            result == expected
+        ), f"Expected {mask_name} to be {expected}, got {result}"
 
 
 class TestLongitudinalStudyIntegration:
@@ -442,14 +470,6 @@ class TestLongitudinalStudyEdgeCases:
         # Should return array of all zeros
         assert np.all(result == 0)
         assert result.shape == (10, 10, 10)
-
-    def test_lesion_numbering_edge_cases(self):
-        """Test that lesion numbering works for edge cases."""
-        study = TestLongitudinalStudyFixtures.create_minimal_study()
-
-        # Test boundary lesion numbers
-        assert "Lesion_1" in study._VALID_MASKS
-        assert "Lesion_99999" in study._VALID_MASKS
 
 
 class TestLongitudinalStudyPerformance:

--- a/tests/test_longitudinal_study.py
+++ b/tests/test_longitudinal_study.py
@@ -20,7 +20,7 @@ class TestLongitudinalStudyFixtures:
 
     @staticmethod
     def create_mock_sitk_image(
-        shape=(10, 10, 10), spacing=(1.0, 1.0, 1.0), origin=(0.0, 0.0, 0.0)
+        shape=(7, 10, 12), spacing=(1.0, 1.0, 1.0), origin=(0.0, 0.0, 0.0)
     ):
         """Create a minimal mock SimpleITK image for testing.
 
@@ -60,7 +60,7 @@ class TestLongitudinalStudyFixtures:
         )
 
     @staticmethod
-    def create_minimal_study(num_timepoints=2, modality="NM", image_shape=(10, 10, 10)):
+    def create_minimal_study(num_timepoints=2, modality="NM", image_shape=(6, 10, 13)):
         """Create a minimal LongitudinalStudy for testing.
 
         Args:
@@ -103,9 +103,9 @@ class TestLongitudinalStudyInit:
         assert len(study.images) == 2
         assert len(study.meta) == 2
         assert len(study.masks) == 0
-        assert isinstance(study._valid_masks, list)
-        assert "Liver" in study._valid_masks
-        assert "Lesion_1" in study._valid_masks
+        assert isinstance(study._VALID_MASKS, list)
+        assert "Liver" in study._VALID_MASKS
+        assert "Lesion_1" in study._VALID_MASKS
 
     def test_init_mismatched_keys_raises_error(self):
         """Test that mismatched image and metadata keys raise ValueError."""
@@ -135,15 +135,6 @@ class TestLongitudinalStudyInit:
         ):
             LongitudinalStudy(images=images, meta=meta, modality=invalid_modality)
 
-    def test_init_creates_lesion_masks(self):
-        """Test that initialization creates expected number of lesion masks."""
-        study = TestLongitudinalStudyFixtures.create_minimal_study()
-
-        lesion_masks = [
-            mask for mask in study._valid_masks if mask.startswith("Lesion_")
-        ]
-        assert len(lesion_masks) == 999999  # Lesion_1 through Lesion_999999
-
 
 class TestLongitudinalStudyArrayAccess:
     """Test array access methods with mock data."""
@@ -152,7 +143,7 @@ class TestLongitudinalStudyArrayAccess:
     def test_array_at_success(self, mock_get_array):
         """Test successful array access."""
         # Setup mock return value
-        test_array = np.random.rand(10, 10, 10)
+        test_array = np.random.rand(7, 10, 12)
         mock_get_array.return_value = test_array
 
         study = TestLongitudinalStudyFixtures.create_minimal_study()
@@ -374,7 +365,7 @@ class TestLongitudinalStudyPropertyBased:
         ]
 
         for organ in required_organs:
-            assert organ in study._valid_masks
+            assert organ in study._VALID_MASKS
 
 
 class TestLongitudinalStudyIntegration:
@@ -457,14 +448,8 @@ class TestLongitudinalStudyEdgeCases:
         study = TestLongitudinalStudyFixtures.create_minimal_study()
 
         # Test boundary lesion numbers
-        assert "Lesion_1" in study._valid_masks
-        assert "Lesion_999999" in study._valid_masks
-
-        # Test that we have exactly the expected number
-        lesion_count = sum(
-            1 for mask in study._valid_masks if mask.startswith("Lesion_")
-        )
-        assert lesion_count == 999999
+        assert "Lesion_1" in study._VALID_MASKS
+        assert "Lesion_99999" in study._VALID_MASKS
 
 
 class TestLongitudinalStudyPerformance:


### PR DESCRIPTION
# Refactor and Test LongitudinalStudy Class

Resolves #75 

## Changelog

In this PR I have refactored LongitudinalStudy:

- Renamed the file `LongStudy.py` -> `longitudinal_study.py` to adhere to common python naming conventions
  - >NOTE: You will need to update your imports, see below
- Refactored `create_longitudinal_from_dicom()` -> `LongitudinalStudy.from_dicom()`
  - >NOTE: You will need to update your imports and calling code, see below
- Added tests for most of the methods
  - run `pytest` to run the test suite
- Fixed minor type errors, note that masks are now of type `NDArray[numpy.bool_]`
  - run `mypy pytheranostics/ImagingDS/longitudinal_study.py` to continue to maintain zero type errors

I have also updated some tool settings:

- Re-ordered test execution to run smoke tests first, so quit early if breaking changes have been made
- Increased `mypy` strictness, since we are only running it per-file, rather than on the whole repository
- Fixed `isort` styling to match `black`

## How to update your Jupyter Notebook

To ensure your notebooks continue to work properly, a few lines need to be updated.

Instead of:
```py
from pytheranostics.ImagingDS.LongStudy import create_logitudinal_from_dicom
myLongStudy = create_longitudinal_from_dicom(...)
```

Write:
```py
from pytheranostics.ImagingDS.longitudinal_study import LongitudinalStudy
myLongStudy = LongitudinalStudy.from_dicom(...)
```